### PR TITLE
Actual no_std and add -ffreestanding when building for no OS

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -28,7 +28,7 @@ links = "blst"
 # Binary can be executed on systems similar to the host.
 default = ["std"]
 # When compiled without this feature library is `no_std` compatible
-std = []
+std = ["dep:threadpool"]
 # Compile in portable mode, without ISA extensions.
 # Binary can be executed on all systems.
 portable = []
@@ -48,7 +48,7 @@ glob = "0.3"
 zeroize = { version = "^1.1", features = ["zeroize_derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-threadpool = "^1.8.1"
+threadpool = { version = "^1.8.1", optional = true }
 
 [dev-dependencies]
 rand = "0.7"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -28,6 +28,7 @@ fn assembly(file_vec: &mut Vec<PathBuf>, base_dir: &Path, _arch: &String) {
 fn main() {
     // account for cross-compilation [by examining environment variable]
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
     if target_arch.eq("wasm32") {
         println!("cargo:rustc-cfg=feature=\"no-threads\"");
@@ -131,7 +132,7 @@ fn main() {
         .flag_if_supported("-fno-builtin")
         .flag_if_supported("-Wno-unused-function")
         .flag_if_supported("-Wno-unused-command-line-argument");
-    if target_arch.eq("wasm32") {
+    if target_arch.eq("wasm32") || target_os.eq("none") {
         cc.flag_if_supported("-ffreestanding");
     }
     if !cfg!(debug_assertions) {


### PR DESCRIPTION
Turns out this branch isn't actually no_std because it was still importing the `threadpool` crate. So I've made it so only when the `std` feature is activated, will the threadpool crate get compiled. 